### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) tool that provides up-to-date documentation for npm packages directly in your IDE. This tool fetches the latest README documentation from either the package's GitHub repository or the README bundled with the npm package itself.
 
+<a href="https://glama.ai/mcp/servers/@meanands/npm-package-docs-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@meanands/npm-package-docs-mcp/badge" alt="NPM Package Docs MCP server" />
+</a>
+
 ## What it does
 
 This MCP tool helps your IDE (like Cursor) get the most current documentation for any npm package instead of relying on outdated or incomplete information. It works by:


### PR DESCRIPTION
This PR adds a badge for the [NPM Package Docs MCP](https://glama.ai/mcp/servers/@meanands/npm-package-docs-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@meanands/npm-package-docs-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@meanands/npm-package-docs-mcp/badge" alt="NPM Package Docs MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.